### PR TITLE
Fixed dump.sh permissions

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -2,4 +2,5 @@ FROM alpine:3.4
 RUN apk add --update mysql-client bash openssh-client && rm -rf /var/cache/apk/*
 COPY dump.sh /
 COPY import.sh /
+RUN chmod +x /dump.sh
 ENTRYPOINT ["/dump.sh"]


### PR DESCRIPTION
The cronjob can't start because of the permissions of the entrypoint